### PR TITLE
Fix: ISBN-10 books resulting in malformed records

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3297,12 +3297,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chroma-js": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.1.2.tgz",
-      "integrity": "sha512-IJnETTalXbsLx1eKEgx19d5L6SRM7cH4vINw/99p/M11HCuXGRWL+6YmCm7FWFGIo6dtWuQoQi1dc5yQ7ESIHg==",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
-    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",

--- a/backend/services/books-add.js
+++ b/backend/services/books-add.js
@@ -14,6 +14,9 @@ module.exports = async (newBook) => {
                 newBook.isbn = isbnParsed.isbn13;
             } else {
                 newBook.isbn = undefined;
+                logger.error(
+                    `ISBN Invalid: ${newBook.isbn} could not be parsed`
+                );
             }
         }
 

--- a/backend/services/metadata-add.js
+++ b/backend/services/metadata-add.js
@@ -7,14 +7,14 @@ const addBooks = require("@services/books-add");
 
 module.exports = async (isbn) => {
     try {
-        let book = {};
+        let data = {};
         const response = await getMetadata(isbn);
 
         if (response.metadata.combined) {
-            book = await addBooks(response.metadata.combined);
+            data = await addBooks(response.metadata.combined);
         }
 
-        return { metadata: response.metadata, book: book };
+        return { metadata: response.metadata, ...data };
     } catch (error) {
         logger.warn(error);
         return { errors: error };

--- a/backend/services/metadata-get.js
+++ b/backend/services/metadata-get.js
@@ -24,7 +24,7 @@ module.exports = async (isbn) => {
         }
 
         //Compare ISBN
-        if (data.openlibrary.title || data.openlibrary.title) {
+        if (data.google?.title || data.openlibrary?.title) {
             data.combined.isbn = isbn;
         } else if (data.openlibrary.isbn) {
             data.combined.isbn = data.openlibrary.isbn;


### PR DESCRIPTION
## ❓Context

Fixes issue where ISBN-10 books not being added with ISBN in database record

## 📖 Description

See [issues #3](https://github.com/ryanmccartney/robinson/issues/3)

## Changes in the codebase

* Logs invalid ISBNs that cannot be parsed in backend
* Fixes logic issue in the metadata fetching function that never added the ISBN to the final data if a records was not found in Open Library
* Fixes snack bar return 'undefined' for title of new books

 * [ ] - Frontend changes
 * [x] - Backend changes
 * [ ] - CI/CD and helper script changes
 * [ ] - Documentation changes
