### PR TITLE
Use SSH for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-depth: 0
+            ssh-key: ${{ secrets.DEPLOY_KEY }}
 
         - name: Setup SSH
           run: |
@@ -93,8 +94,6 @@ jobs:
 
         - name: Run release
           run: cd ./backend && npm run release --ci
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     deploy:
       runs-on: ubuntu-latest
       name: Build and Deploy to GHCR


### PR DESCRIPTION
## ❓Context

Use SSH to checkout repo for release, avoid branch protection rule issues.

## Changes in the codebase

 * [ ] - Frontend changes
 * [ ] - Backend changes
 * [x] - CI/CD and helper script changes
 * [ ] - Documentation changes