### PR TITLE
Fix #14 - Add Book button when no other books

### DIFF
--- a/frontend/src/components/NoEbookFound.jsx
+++ b/frontend/src/components/NoEbookFound.jsx
@@ -17,7 +17,7 @@ const NoEbookFound = ({ bookId }) => {
                 color={grey[500]}
                 variant="h3"
             >
-                {"This is no eBook for this title"}
+                {"There is no eBook for this title"}
             </Typography>
             <Typography
                 align="center"

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -8,16 +8,20 @@ import { enqueueSnackbar } from "notistack";
 const NotFound = ({
     link = "shelves",
     label = "shelf",
+    data = {},
     labelPlural,
     mutate = () => {},
 }) => {
     const handleClick = async () => {
-        const data = await fetcher.post(`${link}`, {
-            name: `A new ${label}`,
+        const response = await fetcher.post(`${link}`, {
+            ...{
+                name: `A new ${label}`,
+            },
+            ...data,
         });
 
-        if (data.shelf) {
-            enqueueSnackbar(`Created a ${label} called ${data.shelf.name}`);
+        if (response.shelf) {
+            enqueueSnackbar(`Created a ${label} called ${response.shelf.name}`);
         }
 
         mutate();

--- a/frontend/src/routes/books.jsx
+++ b/frontend/src/routes/books.jsx
@@ -28,7 +28,14 @@ const BooksList = ({ filter }) => {
         }
 
         if (bookCards.length === 0) {
-            return <NotFound label="book" link="books" mutate={booksMutate} />;
+            return (
+                <NotFound
+                    label="book"
+                    link="books"
+                    mutate={booksMutate}
+                    data={{ title: "My First Book" }}
+                />
+            );
         }
 
         return bookCards;

--- a/frontend/src/routes/scan.jsx
+++ b/frontend/src/routes/scan.jsx
@@ -72,7 +72,6 @@ const Scan = () => {
 
         const id = setInterval(processImage, 100);
         return () => clearInterval(id);
-
     }, [barcode]);
 
     useEffect(() => {


### PR DESCRIPTION
## ❓Context

Fix #14 - Add Book button when no other books

## 📖 Description

When creating a book using the `NotFound` component, no title is passed, causing an error. Add new `data` prop to this component and pass the title `My First Book` when on the book page. 

## Changes in the codebase
 * [x] - Frontend changes
 * [ ] - Backend changes
 * [ ] - CI/CD and helper script changes
 * [ ] - Documentation changes