### PR TITLE
Handle NaNs as page numbers from metadata service and add retries

### DIFF
--- a/backend/models/books.js
+++ b/backend/models/books.js
@@ -23,7 +23,7 @@ const userSchema = mongoose.Schema({
     cover: { type: String },
     coverColors: { type: Array },
     ebook: { type: Object },
-    pages: { type: Number, default: 0 },
+    pages: { type: Number, default: 0, set: (v) => (Number.isNaN(v) ? 0 : v) },
     hardback: { type: Boolean, default: false },
     comments: [{ body: String, date: Date, user: String }],
     lastUpdated: { type: Date, type: Date, default: () => new Date() },

--- a/backend/models/books.js
+++ b/backend/models/books.js
@@ -2,7 +2,7 @@ const mongoose = require("@utils/mongoose");
 const id = require("@utils/id");
 const spineWidth = require("@utils/spine-width");
 
-const userSchema = mongoose.Schema({
+const schema = mongoose.Schema({
     bookId: {
         type: String,
         default: () => id(),
@@ -30,11 +30,11 @@ const userSchema = mongoose.Schema({
     order: { type: Number, required: true, default: 0 },
 });
 
-userSchema.virtual("width").get(function () {
+schema.virtual("width").get(function () {
     return spineWidth(this.pages, this.hardback);
 });
 
-userSchema.set("toJSON", { virtuals: true });
-userSchema.set("toObject", { virtuals: true });
+schema.set("toJSON", { virtuals: true });
+schema.set("toObject", { virtuals: true });
 
-module.exports = mongoose.model("books", userSchema);
+module.exports = mongoose.model("books", schema);

--- a/backend/utils/fetch-retry.js
+++ b/backend/utils/fetch-retry.js
@@ -1,0 +1,34 @@
+const logger = require("@utils/logger")(module);
+
+const fetchRetry = async (
+    url,
+    options = {},
+    { retries = 3, retryDelay = 500 } = {}
+) => {
+    let lastError;
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        let response;
+        try {
+            response = await fetch(url, options);
+            logger.info(
+                `Request attempt ${attempt + 1} for ${url} returned status ${response.status}`
+            );
+            if (response.status >= 500 && response.status < 600) {
+                throw new Error(`Server error: ${response.status}`);
+            }
+
+            return response;
+        } catch (err) {
+            lastError = err;
+
+            if (attempt >= retries) {
+                return response;
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        }
+    }
+};
+
+module.exports = fetchRetry;

--- a/backend/utils/fetch-retry.js
+++ b/backend/utils/fetch-retry.js
@@ -11,7 +11,7 @@ const fetchRetry = async (
         let response;
         try {
             response = await fetch(url, options);
-            logger.info(
+            logger.debug(
                 `Request attempt ${attempt + 1} for ${url} returned status ${response.status}`
             );
             if (response.status >= 500 && response.status < 600) {

--- a/backend/utils/metadata-google.js
+++ b/backend/utils/metadata-google.js
@@ -2,6 +2,7 @@
 
 const logger = require("@utils/logger")(module);
 const getImage = require("@utils/image-get");
+const fetchRetry = require("@utils/fetch-retry");
 
 module.exports = async (isbn) => {
     let data = {};
@@ -9,14 +10,29 @@ module.exports = async (isbn) => {
 
     try {
         if (isbn) {
-            const response = await fetch(
+            const response = await fetchRetry(
                 `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`
             );
+            if (!response.ok) {
+                logger.warn(
+                    `Google books API request for ${isbn} returned status ${response.status}`
+                );
+                return {};
+            }
             data = await response.json();
+        } else {
+            logger.warn(`Google books API request no ISBN provided`);
+            return {};
+        }
+
+        if (!data?.items || data?.items?.length === 0) {
+            logger.warn(
+                `Google books API request for ${isbn} returned no results`
+            );
+            return {};
         }
 
         const book = data?.items[0];
-
         logger.info(`Google books API request for ${isbn}`);
         logger.debug(JSON.stringify(book, undefined, 4));
 

--- a/backend/utils/metadata-openlibrary.js
+++ b/backend/utils/metadata-openlibrary.js
@@ -2,6 +2,7 @@
 
 const logger = require("@utils/logger")(module);
 const getImage = require("@utils/image-get");
+const fetchRetry = require("@utils/fetch-retry");
 
 module.exports = async (isbn) => {
     let data = {};
@@ -10,10 +11,19 @@ module.exports = async (isbn) => {
 
     try {
         if (isbn) {
-            const response = await fetch(
+            const response = await fetchRetry(
                 `https://openlibrary.org/isbn/${isbn}.json`
             );
+            if (!response.ok) {
+                logger.warn(
+                    `Open library API request for ${isbn} returned status ${response.status}`
+                );
+                return {};
+            }
             data = await response.json();
+        } else {
+            logger.warn(`Open library API request no ISBN provided`);
+            return {};
         }
 
         if (data?.covers) {


### PR DESCRIPTION
## ❓Context

Occasionally, Open Library returns `NaN` as a page number, this update improves handling of this case. This fixes part of the issue raised in #20.

Sometime 503 responses are observed from the Google Books API. This appears to be intermittent. Makes metadata fetching more robust by introducing retries. Fixes main issue raised in #20.

## 📖 Description

Explicitly check page numbers are a number, if not default to 0.

Makes three retries with 500ms in between for failed metadata requests (only 5xx series errors). If all fail the final response is delivered.

Adds improved logging to isolate reason for metadata failures in future.

## Changes in the codebase

Updates to book model, handle NaN and fix naming. Add `fetchRetry` function and uses this for making metadata requests.

 * [ ] - Frontend changes
 * [x] - Backend changes
 * [ ] - CI/CD and helper script changes
 * [ ] - Documentation changes