### PR TITLE
feat: add optional GOOGLE_BOOKS_API_KEY environment variable support

### DIFF
--- a/backend/utils/metadata-google.js
+++ b/backend/utils/metadata-google.js
@@ -10,9 +10,9 @@ module.exports = async (isbn) => {
 
     try {
         if (isbn) {
-            const response = await fetchRetry(
-                `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`
-            );
+            const apiKey = process.env.GOOGLE_BOOKS_API_KEY;
+            const url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}${apiKey ? `&key=${apiKey}` : ""}`;
+            const response = await fetchRetry(url);
             if (!response.ok) {
                 logger.warn(
                     `Google books API request for ${isbn} returned status ${response.status}`

--- a/docs/pages/installation/environment.md
+++ b/docs/pages/installation/environment.md
@@ -7,19 +7,20 @@ nav_order: 1
 
 # Environment Variables
 
-| Variable       | Default        | Type    | Description |
-|----------------|----------------|---------|-------------|
-| PORT           | 80             | Integer | The port opened by express.js inside the container |
-| NODE_ENV       | production     | String  | Is it a production of development version of the application |
-| DB_NAME        | robinson       | String  | The MongoDB database name |
-| DB_USER        | robinson       | String  | The MongoDB username |
-| DB_PASSWORD    | robinson123    | String  | The MongoDB password |
-| DB_HOST        | mongo          | String  | The MongoDB host |
-| SESSION_SECRET | pleaseChangeMe | String  |             |
-| SESSION_SECURE | false          | Boolean | Set to true if using behind HTTPs |
-| HOST           | localhost      | String  |             |
-| LOG_FOLDER     | logs           | String  |             |
-| LOG_NAME       | robinson       | String  |             |
-| LOG_LEVEL      | info           | String  |             |
-| PROXY_ADDRESS  | undefined      | String  |             |
-| RATE_LIMIT     | 1000           | Integer |             |
+| Variable              | Default        | Type    | Description |
+|-----------------------|----------------|---------|-------------|
+| PORT                  | 80             | Integer | The port opened by express.js inside the container |
+| NODE_ENV              | production     | String  | Is it a production of development version of the application |
+| DB_NAME               | robinson       | String  | The MongoDB database name |
+| DB_USER               | robinson       | String  | The MongoDB username |
+| DB_PASSWORD           | robinson123    | String  | The MongoDB password |
+| DB_HOST               | mongo          | String  | The MongoDB host |
+| SESSION_SECRET        | pleaseChangeMe | String  |             |
+| SESSION_SECURE        | false          | Boolean | Set to true if using behind HTTPs |
+| HOST                  | localhost      | String  |             |
+| LOG_FOLDER            | logs           | String  |             |
+| LOG_NAME              | robinson       | String  |             |
+| LOG_LEVEL             | info           | String  |             |
+| PROXY_ADDRESS         | undefined      | String  |             |
+| RATE_LIMIT            | 1000           | Integer |             |
+| GOOGLE_BOOKS_API_KEY  |                | String  | Optional Google Books API key. When set, appended to ISBN lookup requests to use an authenticated quota and avoid rate limiting |


### PR DESCRIPTION
Closes #24

Adds support for an optional `GOOGLE_BOOKS_API_KEY` environment variable in `backend/utils/metadata-google.js`. When the variable is set it is appended to the Google Books API request URL as `&key=`. When absent, behaviour is unchanged — the request is made without a key exactly as before.

This addresses the `429 RESOURCE_EXHAUSTED` response currently returned by the Google Books API for unauthenticated requests.