### PR TITLE
Require auth on /search and fix regex injection (unauthenticated DoS)

### DIFF
--- a/backend/routes/search.js
+++ b/backend/routes/search.js
@@ -1,5 +1,8 @@
+"use strict";
+
 const router = require("express").Router();
 const response = require("@utils/response");
+const auth = require("@utils/auth");
 const getSearch = require("@services/search-get");
 
 /**
@@ -27,7 +30,7 @@ const getSearch = require("@services/search-get");
  *         '405':
  *           description: Incorrect request data
  */
-router.get("/", async (req, res) => {
+router.get("/", auth.restrict(["get_data"]), async (req, res) => {
     const data = await getSearch(req?.query?.query);
     response(res, req, data);
 });

--- a/backend/services/search-get.js
+++ b/backend/services/search-get.js
@@ -3,6 +3,12 @@
 const getError = require("@utils/error-get");
 const booksModel = require("@models/books");
 
+// Escape regex metacharacters so a caller-supplied query can only ever
+// match as a literal substring - prevents both malformed-pattern errors
+// and catastrophic-backtracking (ReDoS) patterns from reaching $regex.
+const escapeRegExp = (string) =>
+    string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 module.exports = async (
     query,
     fields = ["books", "author", "title", "description"]
@@ -10,11 +16,12 @@ module.exports = async (
     try {
         const data = { results: [] };
         if (query) {
+            const safeQuery = escapeRegExp(query);
             if (fields.includes("books")) {
                 if (fields.includes("title")) {
                     data.results = data.results.concat(
                         await booksModel.find(
-                            { title: { $regex: query, $options: "i" } },
+                            { title: { $regex: safeQuery, $options: "i" } },
                             { cover: 0 }
                         )
                     );
@@ -22,7 +29,7 @@ module.exports = async (
                 if (fields.includes("author")) {
                     data.results = data.results.concat(
                         await booksModel.find(
-                            { author: { $regex: query, $options: "i" } },
+                            { author: { $regex: safeQuery, $options: "i" } },
                             { cover: 0 }
                         )
                     );
@@ -31,7 +38,7 @@ module.exports = async (
                     data.results = data.results.concat(
                         await booksModel.find(
                             {
-                                description: { $regex: query, $options: "i" },
+                                description: { $regex: safeQuery, $options: "i" },
                             },
                             { cover: 0 }
                         )

--- a/backend/services/search-get.js
+++ b/backend/services/search-get.js
@@ -6,8 +6,7 @@ const booksModel = require("@models/books");
 // Escape regex metacharacters so a caller-supplied query can only ever
 // match as a literal substring - prevents both malformed-pattern errors
 // and catastrophic-backtracking (ReDoS) patterns from reaching $regex.
-const escapeRegExp = (string) =>
-    string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 module.exports = async (
     query,
@@ -38,7 +37,10 @@ module.exports = async (
                     data.results = data.results.concat(
                         await booksModel.find(
                             {
-                                description: { $regex: safeQuery, $options: "i" },
+                                description: {
+                                    $regex: safeQuery,
+                                    $options: "i",
+                                },
                             },
                             { cover: 0 }
                         )


### PR DESCRIPTION
## Problem

Found while doing a full-repository review of our self-hosted instance after tracking down an unrelated login bug (see #29).

`backend/routes/search.js` is the only data-returning route in the app with no `auth.restrict(...)` guard. Compare it directly against its sibling `backend/routes/metadata.js`:

```js
// metadata.js — every route is gated
router.get("/:isbn", auth.restrict(["get_data"]), async (req, res, next) => { ... });

// search.js — as it stands today, no gate at all
router.get("/", async (req, res) => {
    const data = await getSearch(req?.query?.query);
    response(res, req, data);
});
```

I verified this directly against a running instance: `GET /api/search?query=...` returns full results with **no session cookie sent at all** — any unauthenticated caller on the network can enumerate every book's title, author, and description in the library.

That alone would just be an information-disclosure gap, but it compounds with a second issue in `backend/services/search-get.js`: the raw `query` string is passed straight into MongoDB's `$regex` with no escaping:

```js
await booksModel.find({ title: { $regex: query, $options: "i" } }, { cover: 0 })
```

Because there's no auth in front of it, an anonymous caller can submit a regex pattern designed for catastrophic backtracking (e.g. an alternation like `(a+)+$`) and force an expensive scan across the whole `books` collection — a cheap, no-account-required denial-of-service lever, since nothing else in the request path (the `express-rate-limit` middleware) accounts for per-request cost, only per-request count.

## Fix

- `routes/search.js`: add `auth.restrict(["get_data"])`, matching the permission level already used for the read-only `GET /metadata/:isbn` route. This is the minimal, correct permission — `get_data` is granted to every role (member/curator/librarian), so this doesn't change who can search, only that *some* account is now required, closing the anonymous-access gap.
- `services/search-get.js`: escape regex metacharacters (`escapeRegExp`) before the query reaches `$regex`. This closes the ReDoS vector at the source rather than only relying on the auth check — even an authenticated user's search input can no longer reach `$regex` as anything other than a literal substring match, so search behavior for normal queries (plain text, case-insensitive substring matching) is unchanged.

## Verification

Tested against our deployment:
- `GET /search?query=foo` with no session cookie now returns a clean `401` instead of results.
- `GET /search?query=foo` with a valid session still returns matching books, authors, and descriptions exactly as before.
- `GET /search?query=(a%2B)%2B$` (an escaped `(a+)+$`) with a valid session now returns an empty result set instantly instead of being interpreted as a regex — confirming the escaping is effective without needing to actually trigger the backtracking blowup to prove it.

No behavior changes for the normal search flow — this only closes the two gaps above.
