### PR TITLE
Fix orphaned-books filter, shelf/case mixup, stale updates, and ID mass-assignment

### DIFF
--- a/backend/services/books-add.js
+++ b/backend/services/books-add.js
@@ -8,6 +8,12 @@ const coverColor = require("@utils/cover-color");
 
 module.exports = async (newBook) => {
     try {
+        // bookId/dateAdded are server-generated identity fields - Mongoose's
+        // `immutable` only blocks changes on save, not on initial creation,
+        // so a client-supplied value here would otherwise be accepted as-is.
+        delete newBook.bookId;
+        delete newBook.dateAdded;
+
         if (newBook.isbn) {
             const isbnParsed = isbn.parse(newBook.isbn);
             if (isbnParsed) {

--- a/backend/services/books-get-orphaned.js
+++ b/backend/services/books-get-orphaned.js
@@ -18,12 +18,12 @@ module.exports = async () => {
         }
 
         for (const book of books) {
-            if (shelvesId.includes(book.bookId)) {
+            if (!book.shelfId || !shelvesId.includes(book.shelfId)) {
                 orphanedBooks.push(book);
             }
         }
 
-        return { shelves: shelves, books: books };
+        return { shelves: shelves, books: orphanedBooks };
     } catch (error) {
         return getError(error);
     }

--- a/backend/services/cases-add.js
+++ b/backend/services/cases-add.js
@@ -6,6 +6,10 @@ const casesModel = require("@models/cases");
 
 module.exports = async (newCase) => {
     try {
+        // caseId is a server-generated identity field - Mongoose's
+        // `immutable` only blocks changes on save, not on initial creation.
+        delete newCase.caseId;
+
         const cases = new casesModel(newCase);
         await cases.save();
         logger.info(

--- a/backend/services/cases-update.js
+++ b/backend/services/cases-update.js
@@ -8,7 +8,8 @@ module.exports = async (caseId, update) => {
         if (caseId) {
             const bookcase = await casesModel.findOneAndUpdate(
                 { caseId: caseId },
-                { ...update, ...{ lastUpdated: new Date() } }
+                { ...update, ...{ lastUpdated: new Date() } },
+                { new: true, lean: true }
             );
             if (bookcase) {
                 logger.info(

--- a/backend/services/shelves-add.js
+++ b/backend/services/shelves-add.js
@@ -5,6 +5,10 @@ const shelvesModel = require("@models/shelves");
 
 module.exports = async (newShelf) => {
     try {
+        // shelfId is a server-generated identity field - Mongoose's
+        // `immutable` only blocks changes on save, not on initial creation.
+        delete newShelf.shelfId;
+
         const shelf = new shelvesModel(newShelf);
         await shelf.save();
         logger.info(

--- a/backend/services/shelves-get.js
+++ b/backend/services/shelves-get.js
@@ -38,8 +38,11 @@ module.exports = async (shelfId, filter = {}) => {
                     0
                 );
 
-                const bookcase = await booksModel.findOne({ shelfId: shelfId });
-                data.shelf.case = bookcase ? bookcase.toObject() : undefined;
+                data.shelf.case = data.shelf.caseId
+                    ? await casesModel
+                          .findOne({ caseId: data.shelf.caseId })
+                          .lean()
+                    : undefined;
             }
         } else {
             data.shelves = await shelvesModel.find().sort(filter);

--- a/backend/services/shelves-update.js
+++ b/backend/services/shelves-update.js
@@ -8,7 +8,8 @@ module.exports = async (shelfId, update) => {
         if (shelfId) {
             const shelf = await shelvesModel.findOneAndUpdate(
                 { shelfId: shelfId },
-                { ...update, ...{ lastUpdated: new Date() } }
+                { ...update, ...{ lastUpdated: new Date() } },
+                { new: true, lean: true }
             );
             if (shelf) {
                 logger.info(


### PR DESCRIPTION
## Context

Five independent bugs found in the same review pass, grouped into one PR because they're all in the books/cases/shelves layer and touch the same models — easier to review together than as five one-line PRs.

## 1. `books-get-orphaned.js` — the Orphaned view has never filtered anything

```js
for (const book of books) {
    if (shelvesId.includes(book.bookId)) {   // comparing a book's OWN id...
        orphanedBooks.push(book);            // ...against a list of SHELF ids
    }
}
return { shelves: shelves, books: books };   // ...and then returns the unfiltered list anyway
```

Two bugs stacked on top of each other: the condition compares `book.bookId` against `shelvesId` — two different ID spaces that can never intersect, so `orphanedBooks` is always empty — and then the function ignores `orphanedBooks` entirely and returns the full, unfiltered `books` array. `GET /books/orphaned` has always returned every book in the library, not just unshelved ones.

**Fix:** check whether `book.shelfId` is missing or not a currently-existing shelf, and return that filtered array instead of the raw list.

## 2. `shelves-get.js` — a shelf's "case" is actually a random book on it

```js
const bookcase = await booksModel.findOne({ shelfId: shelfId });   // <- booksModel, not casesModel
data.shelf.case = bookcase ? bookcase.toObject() : undefined;
```

This is in the single-shelf lookup branch. The multi-shelf branch six lines later in the *same file* does the equivalent lookup correctly:

```js
if (shelf.caseId) {
    shelf.case = await casesModel.findOne({ caseId: shelf.caseId });
}
```

Side-by-side, it's clearly an inconsistency rather than intentional — `GET /shelves/:shelfId` mislabels an arbitrary book on the shelf as the shelf's bookcase.

**Fix:** match the working branch's pattern — look up via `casesModel.findOne({ caseId: shelf.caseId })`.

## 3 & 4. Stale data returned after case/shelf updates

`cases-update.js` and `shelves-update.js` both call `findOneAndUpdate()` without `{ new: true }`, so `PUT /cases/:caseId` and `PUT /shelves/:shelfId` return the document as it was *before* the save, not after. This is the same class of bug already avoided correctly in `books-update.js` (which does pass `{ new: true, lean: true }`) — these two just missed it.

**Fix:** add `{ new: true, lean: true }` to both calls.

## 5. Clients can set their own record IDs on create

```js
const book = new booksModel(newBook);   // newBook is req.body, unfiltered
```

Same pattern in `cases-add.js` / `shelves-add.js`. Mongoose's `immutable: true` on `bookId`/`caseId`/`shelfId` only blocks *changes* on save — it does nothing to stop a client from supplying their own value for that field on the initial `POST`. A caller with `add_data` permission can set an arbitrary `bookId`/`caseId`/`shelfId`, defeating the random-ID generator and risking a unique-index collision with an existing record.

**Fix:** `delete` the server-managed identity field (and `dateAdded` for books, which is meant to be immutable/server-set too) from the input object before constructing the model, so the schema's `default: () => id()` always fires regardless of what the client sends.

## Verification

For #1 and #2 the bug is visible directly from the code (comparing the wrong ID space; querying the wrong model) and confirmed by comparing against the correctly-working sibling branch in the same file — no ambiguity about intended behavior. For #3/#4/#5, verified against our own deployment: `PUT /shelves/:shelfId` now returns the updated document immediately instead of the stale one, and a `POST /books` with an attacker-supplied `bookId` in the body is now ignored in favor of the generated ID.

No documentation changes needed — none of these change the documented request/response shape, only correctness of the existing contract.
