### PR TITLE
Harden ebook upload: file-size cap, real zip check, decompression cap

### DIFF
--- a/backend/models/uploads.js
+++ b/backend/models/uploads.js
@@ -6,5 +6,13 @@ const bucket = new GridFSBucket(mongoose.connection, {
     bucketName: "uploads",
 });
 
-module.exports = multer();
+// Generous headroom for a real epub (rarely more than a few tens of MB
+// even with embedded images/fonts) while bounding the worst case - multer
+// previously had no limit at all, so an authenticated upload could buffer
+// an arbitrarily large file fully in memory before it reached GridFS.
+const MAX_UPLOAD_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB
+
+module.exports = multer({
+    limits: { fileSize: MAX_UPLOAD_SIZE_BYTES },
+});
 module.exports.bucket = bucket;

--- a/backend/services/books-add-ebook.js
+++ b/backend/services/books-add-ebook.js
@@ -7,9 +7,20 @@ const { finished } = require("stream/promises");
 const deleteEbook = require("@services/books-delete-ebook");
 const epub = require("@utils/epub");
 
+// All zip local file headers begin with this signature - checking it
+// catches a renamed non-zip file before it reaches the zip parser, since
+// the client-supplied mimetype/Content-Type alone is trivially spoofable.
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b]); // "PK"
+
 module.exports = async (bookId, userId, file) => {
     try {
-        if (bookId && file && file.mimetype === "application/epub+zip") {
+        if (
+            bookId &&
+            file &&
+            file.mimetype === "application/epub+zip" &&
+            file.buffer?.length >= 2 &&
+            file.buffer.subarray(0, 2).equals(ZIP_MAGIC)
+        ) {
             await deleteEbook(bookId);
 
             const metadata = await epub.metadata(file.buffer);

--- a/backend/utils/epub.js
+++ b/backend/utils/epub.js
@@ -5,10 +5,20 @@ const parser = new XMLParser({
     ignoreAttributes: false,
 });
 
+// Comfortably larger than any real epub metadata (.opf) file - guards
+// against a zip-bomb-style entry (tiny compressed size, huge declared
+// uncompressed size) being fully inflated into memory on every upload.
+const MAX_ENTRY_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB
+
 const unzipAndGrab = async (zipBuffer, filePath) => {
     const directory = await unzipper.Open.buffer(zipBuffer);
     for (const file of directory.files) {
         if (file.path.includes(filePath)) {
+            if (file.uncompressedSize > MAX_ENTRY_SIZE_BYTES) {
+                throw new Error(
+                    `Refusing to extract ${file.path}: declared uncompressed size ${file.uncompressedSize} bytes exceeds ${MAX_ENTRY_SIZE_BYTES} byte limit`
+                );
+            }
             const contentBuffer = await file.buffer();
             return contentBuffer.toString("utf8");
         }


### PR DESCRIPTION
## Problem

Two related memory-exhaustion (DoS) gaps in the ebook upload path, found in the same review pass.

**1. No file-size limit on upload**

```js
// models/uploads.js
module.exports = multer();   // no options at all
```

`multer()` is instantiated with no `limits`. Combined with `books-add-ebook.js` checking only the client-supplied `file.mimetype` (a header the client fully controls, trivially spoofable) before buffering the whole upload in memory, any authenticated user with `update_data` permission can upload an arbitrarily large file that gets fully buffered before anything rejects it.

**2. No cap on epub decompression**

```js
// utils/epub.js
for (const file of directory.files) {
    if (file.path.includes(filePath)) {
        const contentBuffer = await file.buffer();   // fully inflates the entry first
        return contentBuffer.toString("utf8");
    }
}
```

`unzipper`'s directory listing exposes each entry's **declared** `uncompressedSize` from the zip central directory *before* you call `.buffer()` to actually inflate it. A crafted `.epub` (small compressed size, huge declared uncompressed size for its `.opf` metadata entry — a classic zip-bomb shape) gets fully decompressed into memory on every upload attempt, with the size check happening nowhere.

## Fix

- `models/uploads.js`: add `multer({ limits: { fileSize: 100 * 1024 * 1024 } })`. 100MB is generous headroom — real epub files are rarely more than a few tens of MB even with many embedded images/fonts — while bounding the worst case.
- `services/books-add-ebook.js`: in addition to the existing mimetype check, verify the first two bytes of the buffer match the zip local-file-header signature (`PK`) before trusting the upload. This is a real content check (the actual bytes), not just the spoofable `Content-Type` header — a renamed non-zip file is now rejected before it ever reaches the zip parser.
- `utils/epub.js`: check each matched entry's declared `uncompressedSize` against a 20MB cap *before* calling `.buffer()`, so a zip-bomb-style entry is refused based on its declared size instead of actually being inflated into memory first. 20MB is comfortably larger than any real epub `.opf` metadata file (these are typically a few KB).

## Why these limits

Neither cap changes behavior for a legitimate epub upload — real epub files and their internal metadata files are orders of magnitude smaller than either ceiling. Both are pure safety margins against the abuse case, not functional restrictions.

## Verification

Tested against our deployment: a well-formed epub still uploads and parses metadata identically to before. A non-zip file renamed to `.epub` with a spoofed `Content-Type: application/epub+zip` is now rejected at the magic-byte check instead of reaching the zip parser.

No documentation changes needed — this doesn't change any documented request/response shape or environment variable, only internal safety limits on an existing endpoint.
