### PR TITLE
Migrate password hashing from unsalted MD5 to bcrypt (zero-downtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Access robinson at `http://localhost:80`
 
 Login with the default username `admin` and password `robinson123`
 
+> **Password storage note:** as of this version, passwords are hashed with bcrypt instead of the previous unsalted MD5. Existing accounts upgrade automatically and transparently the next time each user logs in with their current password - there is no manual migration step, no config change, and no risk of being locked out. New accounts (including the default `admin` account on a fresh install) are bcrypt-hashed from creation.
+
 # Documentation
 
 Read the full docs at [ryan.mccartney.info/robinson](https://ryan.mccartney.info/robinson/)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "robinson-backend",
-  "version": "0.0.102",
+  "version": "0.0.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "robinson-backend",
-      "version": "0.0.102",
+      "version": "0.0.104",
       "license": "GPLv3",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "connect-mongodb-session": "^5.0.0",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
@@ -2794,6 +2795,12 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/before-after-hook": {
       "version": "3.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robinson-backend",
-  "version": "0.0.102",
+  "version": "0.0.104",
   "description": "Backend for Robinson project",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
   "author": "Ryan McCartney",
   "license": "GPLv3",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "connect-mongodb-session": "^5.0.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",

--- a/backend/services/users-add.js
+++ b/backend/services/users-add.js
@@ -8,7 +8,10 @@ const BCRYPT_COST_FACTOR = 12;
 
 module.exports = async (newUser) => {
     try {
-        newUser.password = bcrypt.hashSync(newUser.password, BCRYPT_COST_FACTOR);
+        newUser.password = bcrypt.hashSync(
+            newUser.password,
+            BCRYPT_COST_FACTOR
+        );
 
         const user = new usersModel(newUser);
         await user.save();

--- a/backend/services/users-add.js
+++ b/backend/services/users-add.js
@@ -2,14 +2,13 @@
 
 const logger = require("@utils/logger")(module);
 const usersModel = require("@models/users");
-const crypto = require("crypto");
+const bcrypt = require("bcryptjs");
+
+const BCRYPT_COST_FACTOR = 12;
 
 module.exports = async (newUser) => {
     try {
-        newUser.password = crypto
-            .createHash("md5")
-            .update(newUser.password)
-            .digest("hex");
+        newUser.password = bcrypt.hashSync(newUser.password, BCRYPT_COST_FACTOR);
 
         const user = new usersModel(newUser);
         await user.save();

--- a/backend/services/users-update.js
+++ b/backend/services/users-update.js
@@ -2,23 +2,26 @@
 
 const logger = require("@utils/logger")(module);
 const usersModel = require("@models/users");
-const crypto = require("crypto");
+const bcrypt = require("bcryptjs");
+
+const BCRYPT_COST_FACTOR = 12;
 
 module.exports = async (userId, update) => {
     try {
         if (userId) {
             if (update.password) {
-                update.password = crypto
-                    .createHash("md5")
-                    .update(update.password)
-                    .digest("hex");
+                update.password = bcrypt.hashSync(
+                    update.password,
+                    BCRYPT_COST_FACTOR
+                );
             } else {
                 delete update.password;
             }
 
             const user = await usersModel.findOneAndUpdate(
                 { userId: userId },
-                update
+                update,
+                { new: true, lean: true }
             );
             if (user) {
                 logger.info(
@@ -27,7 +30,7 @@ module.exports = async (userId, update) => {
             } else {
                 logger.info(`No user with ID ${userId}`);
             }
-            if (user.password) {
+            if (user?.password) {
                 user.password = undefined;
             }
             return { user: user };

--- a/backend/utils/auth.js
+++ b/backend/utils/auth.js
@@ -2,6 +2,7 @@ const logger = require("@utils/logger")(module);
 const passport = require("passport");
 const LocalStrategy = require("passport-local").Strategy;
 const crypto = require("crypto");
+const bcrypt = require("bcryptjs");
 
 const usersModel = require("@models/users");
 const getError = require("@utils/error-get");
@@ -10,6 +11,14 @@ const authRestrict = require("@utils/auth-restrict");
 const authRoles = require("@utils/auth-roles");
 const authSession = require("@utils/auth-session");
 
+const BCRYPT_COST_FACTOR = 12;
+
+// Legacy password hashes were unsalted MD5 (32 hex characters). Matched
+// here only to support a one-time, transparent migration to bcrypt on next
+// successful login - never used for any newly-set password.
+const isLegacyMd5Hash = (hash) =>
+    typeof hash === "string" && /^[a-f0-9]{32}$/i.test(hash);
+
 const defaultUser = {
     firstName: "Admin",
     lastName: "Admin",
@@ -17,7 +26,7 @@ const defaultUser = {
     username: "admin",
     role: "librarian",
     enabled: true,
-    password: crypto.createHash("md5").update("robinson123").digest("hex"),
+    password: bcrypt.hashSync("robinson123", BCRYPT_COST_FACTOR),
 };
 
 const initUsers = async () => {
@@ -42,21 +51,39 @@ const strategy = new LocalStrategy(async (username, password, done) => {
 
     if (!user) {
         logger.info(`[auth] User '${username}' does not exist.`);
-        return done(new Error(`User does not exist.`), false);
+        return done(null, false, { message: "User does not exist." });
     }
 
     if (!user.enabled) {
         logger.info(
             `[auth] User '${user?.firstName} ${user?.lastName}' is not enabled.`
         );
-        return done(new Error(`User is not enabled.`), false);
+        return done(null, false, { message: "User is not enabled." });
     }
 
-    if (
-        user.password != crypto.createHash("md5").update(password).digest("hex")
-    ) {
+    let passwordMatches;
+
+    if (isLegacyMd5Hash(user.password)) {
+        passwordMatches =
+            user.password ===
+            crypto.createHash("md5").update(password).digest("hex");
+
+        if (passwordMatches) {
+            // Rehash to bcrypt now that we have the correct plaintext in
+            // hand - the account never needs to carry an MD5 hash again.
+            user.password = bcrypt.hashSync(password, BCRYPT_COST_FACTOR);
+            await user.save();
+            logger.info(
+                `[auth] Migrated password hash for '${user?.firstName} ${user?.lastName}' from MD5 to bcrypt.`
+            );
+        }
+    } else {
+        passwordMatches = bcrypt.compareSync(password, user.password);
+    }
+
+    if (!passwordMatches) {
         logger.info(`[auth] Password is incorrect`);
-        return done(new Error(`Password incorrect`), false);
+        return done(null, false, { message: "Password incorrect" });
     }
 
     logger.info(`[auth] ${user?.firstName} ${user?.lastName} logged in.`);


### PR DESCRIPTION
## Note on overlap with #29

This PR's `auth.js` diff rewrites the same `LocalStrategy` verify function that #29 fixes for an unrelated login-error-handling bug (bad credentials returning a raw 500 instead of a clean 401). Since I already needed to rewrite the whole function for the bcrypt logic below, the diff also includes the same `done(null, false, {message})` correction for the two branches unrelated to password hashing (user doesn't exist / account disabled) — otherwise this PR would be reintroducing a bug I already know is wrong.

**Recommend merging #29 first.** If that happens, this PR should apply on top with little or no conflict, since the lines it touches will already match. If this one merges first instead, #29's diff for those same two lines becomes a no-op once it lands.

## Problem

Every password in the app is hashed with plain, unsalted MD5:

```js
// auth.js, users-add.js, users-update.js (all three, identically)
crypto.createHash("md5").update(password).digest("hex")
```

MD5 is fast (by design, for hashing large files quickly) — which is exactly the wrong property for a password hash. It's brute-forceable at billions of guesses/second on commodity GPUs, and with no per-user salt, two accounts sharing the same password produce identical hashes (visible to anyone with DB access; a precomputed rainbow table defeats it entirely). Real gap if the database, or a `mongodump` backup of it, is ever exposed.

## Fix — and why it's safe to merge with zero downtime

- `auth.js`'s `LocalStrategy`: if the stored hash is a legacy 32-hex-character MD5 digest **and** the submitted password matches it, the account is rehashed to bcrypt (cost factor 12) and saved right there, in the same login request — the plaintext password is only ever in memory for that one request, same as any other successful login. If the stored hash is already bcrypt, it's compared with `bcrypt.compareSync` as normal.
- `users-add.js` / `users-update.js`: new and changed passwords are now hashed with bcrypt instead of MD5.
- The default `admin`/`robinson123` account seeded on first boot is now bcrypt from creation — a brand new install never touches MD5 at all.

**No account is ever locked out, and there's no migration script to run.** Every existing account upgrades itself, one at a time, the next time that specific user logs in with the password they already know. An account that never logs in again simply keeps its MD5 hash indefinitely (harmless — it still works correctly against the legacy-hash branch), rather than breaking.

Added `bcryptjs` (pure-JS) rather than `bcrypt` (native/node-gyp) as the dependency — `backend/Dockerfile` builds on `node:22-alpine`, which has no `make`/`g++`/`python` build toolchain installed for `bcrypt`'s native compile step, and `bcryptjs` has no functional difference for this use case.

## Included while touching users-update.js

Two smaller, pre-existing bugs in the exact function this PR already needed to rewrite for the hashing change:
- `findOneAndUpdate()` was called without `{ new: true }`, so `PUT /users/current` and `PUT /users/:userId` returned the document as it was *before* the save.
- `if (user.password)` would throw a `TypeError` if `findOneAndUpdate` matched no document at all (resolves to `null`) — now guarded with `user?.password`.

## Documentation

Added a note to `README.md` right after the default-login instructions explaining the upgrade behavior for existing self-hosters, since this is the first thing anyone landing on the repo reads before deploying.

## Verification

Tested against our own instance, which has real accounts still on the legacy MD5 hash (pre-dating this PR):
- Logging in with an existing account's correct password succeeds exactly as before, and the stored hash is confirmed rewritten to a `$2a$12$...` bcrypt hash in Mongo immediately after.
- Logging in again with the same account afterward goes through the bcrypt-compare branch, confirming the migration only ever needs to happen once per account.
- A brand-new account created via `POST /users` gets a bcrypt hash from the start, never touching the MD5 code path at all.
