### PR TITLE
Remove dead @validators alias and unused express-validator dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "robinson-backend",
-  "version": "0.0.102",
+  "version": "0.0.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "robinson-backend",
-      "version": "0.0.102",
+      "version": "0.0.104",
       "license": "GPLv3",
       "dependencies": {
         "connect-mongodb-session": "^5.0.0",
@@ -16,7 +16,6 @@
         "express-openapi-validator": "^5.3.5",
         "express-rate-limit": "^7.1.5",
         "express-session": "^1.18.0",
-        "express-validator": "^7.0.1",
         "fast-xml-parser": "^5.2.1",
         "get-image-colors": "^4.0.1",
         "helmet": "^7.1.0",
@@ -4679,19 +4678,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/express-validator": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
-      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "validator": "~13.12.0"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
     },
     "node_modules/express/node_modules/cookie": {
       "version": "0.7.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robinson-backend",
-  "version": "0.0.102",
+  "version": "0.0.104",
   "description": "Backend for Robinson project",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,6 @@
     "express-openapi-validator": "^5.3.5",
     "express-rate-limit": "^7.1.5",
     "express-session": "^1.18.0",
-    "express-validator": "^7.0.1",
     "fast-xml-parser": "^5.2.1",
     "get-image-colors": "^4.0.1",
     "helmet": "^7.1.0",
@@ -65,8 +64,7 @@
     "@routes": "./routes/",
     "@models": "./models/",
     "@utils": "./utils/",
-    "@services": "./services/",
-    "@validators": "./validators/"
+    "@services": "./services/"
   },
   "release-it": {
     "git": {


### PR DESCRIPTION
## Context

Small cleanup found while reviewing how request validation works across the app.

`backend/package.json`'s `_moduleAliases` declares `"@validators": "./validators/"`, and `express-validator` is listed as a dependency — but `backend/validators/` doesn't exist anywhere in the repo, and I confirmed via a repo-wide code search that neither `@validators` nor `express-validator` is referenced by any file. This looks like leftover configuration from an abandoned refactor: the app's actual request validation is `express-openapi-validator`, wired up separately in `bin/app.js` against the Swagger/OpenAPI spec.

## Fix

Removed the dead `@validators` alias and the unused `express-validator` dependency from `backend/package.json`, and regenerated `package-lock.json` to match (ran `npm install` in a clean `node:22-alpine` container against this branch so the lockfile stays in sync for CI's `npm ci`).

## Worth knowing, not fixed here

While confirming `express-openapi-validator` is the real validation layer, I noticed it genuinely enforces the documented path/query parameter schemas on every route, but none of the route JSDoc blocks in the repo currently declare a `requestBody` schema — so POST/PUT bodies get no shape/type validation at the OpenAPI layer before reaching Mongoose. That's a separate, larger piece of work (adding schemas to every route's docs, or building out a real `@validators` layer) than this cleanup, so I've left it as-is and am just flagging it here in case it's useful context for prioritizing future work.

No functional behavior changes — this only removes dead configuration and an unused package.
