### PR TITLE
Fix getInitials crash on empty name and EditableTypography stale state

### DIFF
--- a/frontend/src/components/EditableTypography.jsx
+++ b/frontend/src/components/EditableTypography.jsx
@@ -1,6 +1,6 @@
 import InputBase from "@mui/material/InputBase";
 import Typography from "@mui/material/Typography";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { grey } from "@mui/material/colors";
 
 const InputBaseWithChildren = ({ children, ...props }) => {
@@ -41,6 +41,10 @@ const EditableTypography = ({
     ...props
 }) => {
     const [internalValue, setInternalValue] = useState(props.children);
+
+    useEffect(() => {
+        setInternalValue(props.children);
+    }, [props.children]);
 
     const handleChange = (e) => {
         setInternalValue(e.target.value);

--- a/frontend/src/utils/getInitials.jsx
+++ b/frontend/src/utils/getInitials.jsx
@@ -1,12 +1,14 @@
 const getInitials = (name) => {
+    if (!name) {
+        return "";
+    }
+
     let initials = "";
     const nameArray = name.split(" ");
-    if (name) {
-        for (const word of nameArray) {
-            initials += word.charAt(0);
-        }
-        return initials.toUpperCase();
+    for (const word of nameArray) {
+        initials += word.charAt(0);
     }
+    return initials.toUpperCase();
 };
 
 export default getInitials;


### PR DESCRIPTION
## 1. `getInitials.jsx` throws on an empty/missing name

```js
const getInitials = (name) => {
    let initials = "";
    const nameArray = name.split(" ");   // runs unconditionally...
    if (name) {                          // ...before this guard ever checks
        ...
```

`name.split(" ")` executes before the `if (name)` guard that's clearly meant to protect it — the guard order is just backwards. It's called directly as `getInitials(library?.name)` in `LibrarySelector.jsx`; any library record with a missing/empty `name` field throws a `TypeError` and crashes that render tree.

**Fix:** return an empty string immediately for a falsy `name`, before ever touching `.split()`.

## 2. `EditableTypography.jsx` shows stale text after an external update

```js
const [internalValue, setInternalValue] = useState(props.children);
```

React only reads this initial value once, on mount — there was no effect resyncing `internalValue` when `props.children` changes afterward. If the underlying book/shelf/case record is updated elsewhere (another tab, or a sibling field's save triggering a `mutate()`), this field keeps showing the old text until the whole component unmounts and remounts.

**Fix:** added `useEffect(() => setInternalValue(props.children), [props.children])` so the displayed value tracks the prop whenever it changes from outside, while local edits (`handleChange`) still work exactly as before in between saves.

## Not included in this PR

While reviewing the fetch layer for related issues, I confirmed `auth-session.js`'s session cookie sets no explicit `sameSite` attribute — it currently relies on modern browsers defaulting an unspecified cookie to `Lax` (which already blocks the classic cross-site-POST CSRF vector), rather than the app stating that guarantee explicitly. Making it explicit (`sameSite: "lax"`) would be a good low-risk hardening follow-up, but I've left it out here since it would touch the exact same `auth-session.js` lines #29 already has open for an unrelated fix. Happy to send that as a quick follow-up once #29 lands.

No documentation changes needed for this PR — both fixes are internal correctness fixes with no change to any documented behavior/contract.
