### PR TITLE
Run containers as non-root, use npm ci for reproducible installs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,10 @@
 FROM node:22-alpine
 
 WORKDIR /home/node/app
-COPY . .
+COPY --chown=node:node . .
 
-RUN npm install
+USER node
+
+RUN npm ci
 
 CMD [ "sh", "-c", "npm run $NODE_ENV" ]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,8 @@
 FROM node:22-alpine
 
+USER node
 WORKDIR /home/node/app
 COPY --chown=node:node . .
-
-USER node
 
 RUN npm ci
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,8 @@
 FROM node:22-alpine
 
+USER node
 WORKDIR /home/node/app
 COPY --chown=node:node . .
-
-USER node
 
 #Install Dependencies
 RUN npm ci

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:22-alpine
 
 WORKDIR /home/node/app
-COPY . .
+COPY --chown=node:node . .
+
+USER node
 
 #Install Dependencies
-RUN npm install
+RUN npm ci
 
 #Build
 RUN npm run build


### PR DESCRIPTION
## Problem

Neither `backend/Dockerfile` nor `frontend/Dockerfile` has a `USER` directive — both run the app as root inside the container, unnecessarily widening the blast radius of any future RCE-class bug in either app. Both also use `npm install`, which can silently resolve newer semver-compatible package versions than what's actually pinned in `package-lock.json`, rather than installing exactly what's locked.

## Fix

- `COPY --chown=node:node . .` so the copied source is owned by the unprivileged `node` user node:22-alpine already ships with (no need to create one).
- `USER node` so `npm ci`/`npm run build` and the running app process itself never execute as root.
- `npm install` → `npm ci` for a reproducible, lockfile-exact install.

## A build-order bug I caught in my own fix, worth mentioning

My first pass put `USER node` *after* `WORKDIR` — `WORKDIR` creates the directory as whoever is active at that point in the build, so the directory itself was still created root-owned before `USER node` ever took effect, and `npm ci` failed trying to write `node_modules` as the `node` user despite the copied files being correctly `node`-owned. Fixed by putting `USER node` before `WORKDIR` so the directory is created by the right user from the start. Caught this by actually building both images locally before opening this PR, not just reasoning about the Dockerfile — mentioning it because it's an easy mistake to make with this exact fix and worth watching for in review.

## Deliberately not done: multi-stage build

The obvious further "best practice" step would be a multi-stage build that strips `devDependencies` and the source tree down to just the built output for a slimmer final image. I looked at this and backed off: both `package.json` files use the same `CMD ["sh","-c","npm run $NODE_ENV"]` pattern specifically so the *same* image can run either `development` (`nodemon`/`vite`, needs the full source tree and devDependencies) or `production` depending on the `NODE_ENV` env var at runtime. That's an intentional dual-purpose design, not an oversight — a multi-stage split that removed devDependencies would break the development path this same image is meant to also support. Left the single-stage structure in place.

## Verification

Built both images locally from this branch (`docker build ./backend`, `docker build ./frontend`) — both build successfully, and `docker run --rm <image> whoami` returns `node` for both, confirming neither runs as root. Frontend's `vite build` step still completes and produces the same `build/` output as before.

No documentation changes needed — this doesn't change any documented build/run instructions in the README (`docker compose up -d` still works identically).
