### PR TITLE
Batch of small, independent hardening fixes (fetch-retry, cover-color, ISBN URLs, preferences guards)

### DIFF
--- a/backend/models/preferences.js
+++ b/backend/models/preferences.js
@@ -64,7 +64,7 @@ const findFavourites = async (userId) => {
             },
         ]);
 
-        return data[0].preferences;
+        return data[0]?.preferences ?? [];
     }
     return {};
 };
@@ -86,7 +86,7 @@ const findProgress = async (userId, threshold = 0) => {
             },
         ]);
 
-        return data[0].preferences;
+        return data[0]?.preferences ?? [];
     }
     return {};
 };
@@ -133,7 +133,7 @@ const findOneAndUpdatePreferences = async (userId, query = {}, update = {}) => {
             );
         }
 
-        return parsePreference(preference.preferences);
+        return parsePreference(preference?.preferences);
     }
     return {};
 };

--- a/backend/utils/cover-color.js
+++ b/backend/utils/cover-color.js
@@ -3,6 +3,17 @@
 const logger = require("@utils/logger")(module);
 const getColors = require("get-image-colors");
 
+// get-image-colors is only asked to decode formats it actually supports -
+// anything else (or a non-image mime type claim entirely) is rejected
+// before the buffer is handed to the decoding library.
+const ALLOWED_COVER_MIME_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/webp",
+    "image/gif",
+];
+
 module.exports = async (imageString) => {
     try {
         if (imageString) {
@@ -10,6 +21,14 @@ module.exports = async (imageString) => {
                 .split(",")[0]
                 .split(":")[1]
                 .split(";")[0];
+
+            if (!ALLOWED_COVER_MIME_TYPES.includes(mimeType)) {
+                logger.warn(
+                    `Refusing to process cover with unsupported mime type: ${mimeType}`
+                );
+                return [];
+            }
+
             const buffer = Buffer.from(imageString.split(",")[1], "base64");
 
             let colors = await getColors(buffer, { type: mimeType, count: 2 });

--- a/backend/utils/fetch-retry.js
+++ b/backend/utils/fetch-retry.js
@@ -23,7 +23,10 @@ const fetchRetry = async (
             lastError = err;
 
             if (attempt >= retries) {
-                return response;
+                if (response) {
+                    return response;
+                }
+                throw lastError;
             }
 
             await new Promise((resolve) => setTimeout(resolve, retryDelay));

--- a/backend/utils/metadata-google.js
+++ b/backend/utils/metadata-google.js
@@ -11,7 +11,7 @@ module.exports = async (isbn) => {
     try {
         if (isbn) {
             const response = await fetchRetry(
-                `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`
+                `https://www.googleapis.com/books/v1/volumes?q=isbn:${encodeURIComponent(isbn)}`
             );
             if (!response.ok) {
                 logger.warn(
@@ -37,7 +37,7 @@ module.exports = async (isbn) => {
         logger.debug(JSON.stringify(book, undefined, 4));
 
         parsedData = {
-            author: book?.volumeInfo?.authors[0],
+            author: book?.volumeInfo?.authors?.[0],
             title: book?.volumeInfo?.title,
             subtitle: book?.volumeInfo?.subtitle,
             publisher: book?.volumeInfo?.publisher,
@@ -45,7 +45,7 @@ module.exports = async (isbn) => {
             description: book?.volumeInfo?.description,
             pages: book?.volumeInfo?.pageCount,
             cover: await getImage(book?.volumeInfo?.imageLinks?.thumbnail),
-            isbn: book?.volumeInfo?.industryIdentifiers[1]?.identifier,
+            isbn: book?.volumeInfo?.industryIdentifiers?.[1]?.identifier,
         };
     } catch (error) {
         logger.warn(`Google books API request for ${isbn} failed`);

--- a/backend/utils/metadata-openlibrary.js
+++ b/backend/utils/metadata-openlibrary.js
@@ -12,7 +12,7 @@ module.exports = async (isbn) => {
     try {
         if (isbn) {
             const response = await fetchRetry(
-                `https://openlibrary.org/isbn/${isbn}.json`
+                `https://openlibrary.org/isbn/${encodeURIComponent(isbn)}.json`
             );
             if (!response.ok) {
                 logger.warn(
@@ -43,8 +43,8 @@ module.exports = async (isbn) => {
         parsedData = {
             title: data?.title,
             publishData: data?.publish_date,
-            isbn: data?.isbn_13[0],
-            publisher: data?.publishers[0],
+            isbn: data?.isbn_13?.[0],
+            publisher: data?.publishers?.[0],
             description: data?.subtitle,
             subtitle: data?.subtitle,
             pages: parseInt(data?.pagination),


### PR DESCRIPTION
(Re-opened as a fresh PR/branch — the original #37 had an identical diff but GitHub Actions never triggered a single check run on it despite multiple retrigger attempts (a new commit, then closing/reopening); this is a clean re-post of the same change from a new branch so CI can run normally.)

## Context

Five small, independent issues found in the same review pass, batched together since each is a one-file, few-line fix with no interaction between them — didn't seem worth five separate one-line PRs.

## 1. `fetch-retry.js` swallows real network errors

```js
if (attempt >= retries) {
    return response;   // undefined if fetch() itself threw
}
```

If `fetch()` throws outright (DNS failure, connection refused — not just a non-2xx status), `response` was never assigned, so this returns `undefined` after retries are exhausted. Callers (`metadata-google.js`, `metadata-openlibrary.js`) then do `response.ok`, producing a generic `TypeError` that hides what actually went wrong. **Fix:** only return `response` if one exists (a genuine failed HTTP response, e.g. a persistent 5xx, is still returned as before for status-based handling); otherwise throw the real error.

## 2. `cover-color.js` trusts an unvalidated mime type

The mime type is parsed out of a caller-supplied data URI and passed straight to `get-image-colors` with no check that it's actually a supported image format. **Fix:** added an allow-list (`image/png`, `image/jpeg`, `image/jpg`, `image/webp`, `image/gif`) — anything else is rejected before the buffer ever reaches the decoding library.

## 3 & 4. ISBN not encoded before hitting external metadata APIs

```js
`https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`
`https://openlibrary.org/isbn/${isbn}.json`
```

The ISBN parameter is concatenated directly into both outbound URLs with no `encodeURIComponent` — a crafted value could inject extra query parameters or path segments into the outbound request. **Fix:** encode it in both files.

While in these two files, also fixed unguarded array indexing on fields that are legitimately optional in both APIs' responses (`authors`, `industryIdentifiers` from Google Books; `isbn_13`, `publishers` from Open Library) — currently throws and is silently swallowed by the outer catch whenever a response omits one of these, discarding metadata that was otherwise successfully parsed. Switched to optional chaining (`?.[0]`) throughout.

## 5. `preferences.js` accesses possibly-empty query results unguarded

`findFavourites`/`findProgress` did `data[0].preferences`, which throws if the aggregate matched no user document at all (e.g. a stale/deleted `userId`) instead of degrading to an empty list. `findOneAndUpdatePreferences` had the same pattern on `preference.preferences` when both of its `findOneAndUpdate` attempts came back `null`. Guarded all three with optional chaining + a sensible empty-array fallback.

## Deliberately not fixed here

`findOneAndUpdatePreferences` also passes `"preferences.$": 1` inside the *options* argument of `findOneAndUpdate`, which isn't a valid option there and is silently ignored by Mongoose. Traced this but stopped short of "fixing" it in this PR: the function has two `findOneAndUpdate` call sites with different query shapes — one has a matching `$elemMatch` condition where a positional (`$`) projection would be semantically valid, the other (the `$push`-a-new-preference branch) doesn't have one, so applying the same projection there wouldn't correctly identify the just-pushed element. Without test coverage for this function, didn't want to guess at a fix that could change which preference object gets returned. Flagging it here in case it's useful context, rather than silently leaving it undocumented.

No documentation changes needed — none of these change any documented request/response contract, only internal robustness.
